### PR TITLE
Link libeconf against libm, so that it is enough to link an applicati…

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libeconf.la
 libeconf_la_SOURCES = ../src/libeconf.c ../src/getfilecontents.c ../src/mergefiles.c ../src/helpers.c ../src/keyfile.c
 libeconf_la_CFLAGS = -Wall
-libeconf_la_LDFLAGS = -Wl,--version-script=$(top_srcdir)/lib/libeconf.map
+libeconf_la_LDFLAGS = -Wl,--version-script=$(top_srcdir)/lib/libeconf.map -lm
 
 CLEANFILES = *.pc
 


### PR DESCRIPTION
…on against libeconf and developers don't need to bother with other dependencies