### PR TITLE
Fix pointer arithmetic

### DIFF
--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -158,8 +158,8 @@ Key_File *econf_get_conf_from_dirs(const char *usr_conf_dir,
     free(project_path);
 
     // If /etc configuration exists igonre /usr config
-    if ((size-1) && (default_dirs == default_ptr)) { *default_dirs++; }
-    *default_dirs++;
+    if ((size - 1) && (default_dirs == default_ptr)) { default_dirs++; }
+    default_dirs++;
   }
   key_files[size - 1] = NULL;
 


### PR DESCRIPTION
`*default_dirs++` in src/libeconf.c throws a compiler warning,
since it can cause undefined behaviour, thus it's changed to
`default_dirs++`, which is what's wanted here.

Signed-off-by: Pascal Arlt <parlt@suse.com>