### PR TITLE
Disable searching through XDG dirs for now

### DIFF
--- a/src/mergefiles.c
+++ b/src/mergefiles.c
@@ -103,14 +103,20 @@ size_t add_new_groups(struct file_entry **fe, Key_File *uf, Key_File *ef,
   return added_keys;
 }
 
+
+// TODO: Make this function configureable with econf_set_opt()
 char **get_default_dirs(const char *usr_conf_dir, const char *etc_conf_dir) {
   size_t default_dir_number = 3, dir_num = 0;
-  char **default_dirs = malloc(++default_dir_number * sizeof(char *));
+  char **default_dirs = malloc(default_dir_number * sizeof(char *));
 
   // Set config directory in /etc
   default_dirs[dir_num++] = strdup(etc_conf_dir);
   // Set config directory in /usr
   default_dirs[dir_num++] = strdup(usr_conf_dir);
+
+  #if 0
+  // TODO: Use secure_getenv() instead and check if the variable is actually set
+
   // If XDG_CONFIG_DIRS is set check it as well
   if(getenv("XDG_CONFIG_DIRS")) {
     default_dirs = realloc(default_dirs, ++default_dir_number * sizeof(char *));
@@ -124,6 +130,8 @@ char **get_default_dirs(const char *usr_conf_dir, const char *etc_conf_dir) {
             strlen(getenv("USERNAME")) + 1), "/home/%s/.config",
             getenv("USERNAME"));
   }
+  #endif
+
   default_dirs[dir_num] = NULL;
 
   return default_dirs;


### PR DESCRIPTION
Searching through XDG dirs should be enabled/disabled via a
`econf_set_opt()` function. Until it is implemented the XDG
feature is disabled.

Signed-off-by: Pascal Arlt <parlt@suse.com>