### PR TITLE
setStringValue return NULL on error/key not found

### DIFF
--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -314,9 +314,9 @@ double econf_getDoubleValue(Key_File *kf, char *group, char *key) {
 }
 
 char *econf_getStringValue(Key_File *kf, char *group, char *key) {
-  if (!kf) { errno = ENODATA; return ""; }
+  if (!kf) { errno = ENODATA; return NULL; }
   size_t num = find_key(*kf, group, key);
-  if (num == -1) { errno = ENOKEY; return ""; }
+  if (num == -1) { errno = ENOKEY; return NULL; }
   return getStringValueNum(*kf, num);
 }
 


### PR DESCRIPTION
Change error return value from empty string to NULL.

Signed-off-by: Pascal Arlt <parlt@suse.com>