### PR TITLE
Fix addbrackets function

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -106,7 +106,7 @@ char *addbrackets(const char *string) {
     char *buffer = malloc(length + 3);
     char *cp = buffer;
     *cp++ = '[';
-    stpcpy (cp, string);
+    cp = stpcpy (cp, string);
     *cp++ = ']';
     return buffer;
   }


### PR DESCRIPTION
The closing bracket was not appended at the end as intended.

Signed-off-by: Pascal Arlt <parlt@suse.com>