### PR TITLE
Fix floating point number representation

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -156,18 +156,18 @@ bool setUInt64ValueNum(Key_File *key_file, size_t num, const void *v, econf_err 
 bool setFloatValueNum(Key_File *key_file, size_t num, const void *v, econf_err *error) {
   float *value = (float*) v;
   free(key_file->file_entry[num].value);
-  size_t length = snprintf(NULL, 0, "%.*g", FLT_DECIMAL_DIG - 1, *value);
+  size_t length = snprintf(NULL, 0, "%.*g", FLT_DECIMAL_DIG, *value);
   snprintf(key_file->file_entry[num].value = malloc(length + 1), length + 1, "%.*g",
-           FLT_DECIMAL_DIG - 1, *value);
+           FLT_DECIMAL_DIG, *value);
   return true;
 }
 
 bool setDoubleValueNum(Key_File *key_file, size_t num, const void *v, econf_err *error) {
   double *value = (double*) v;
   free(key_file->file_entry[num].value);
-  size_t length = snprintf(NULL, 0, "%.*g", DBL_DECIMAL_DIG - 1, *value);
+  size_t length = snprintf(NULL, 0, "%.*g", DBL_DECIMAL_DIG, *value);
   snprintf(key_file->file_entry[num].value = malloc(length + 1), length + 1, "%.*g",
-           DBL_DECIMAL_DIG - 1, *value);
+           DBL_DECIMAL_DIG, *value);
   return true;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ TESTS = tst-filedoesnotexit1 tst-merge1 tst-merge2 tst-logindefs1 \
 	tst-setgetvalues1 \
 	tst-groups1
 
-XFAIL_TESTS = tst-setgetvalues1 tst-groups1
+XFAIL_TESTS = tst-groups1
 
 check_PROGRAMS = ${TESTS}
 


### PR DESCRIPTION
Make `tst-setgetvalues1` pass.
Remove `XFAIL` for `tst-setgetvalues1`