### PR TITLE
Prevent possible crash when parsing 0xFF

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = example
-example_SOURCES = $(top_srcdir)/example/example.c
+example_SOURCES = ../example/example.c
 example_CFLAGS = @CFLAGS_CHECKS@ -I $(top_srcdir)/include
-example_LDADD = @LDFLAGS_CHECKS@ $(top_srcdir)/lib/libeconf.la
+example_LDADD = @LDFLAGS_CHECKS@ $(top_builddir)/lib/libeconf.la
 
 CLEANFILES = example

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = example
 example_SOURCES = ../example/example.c
-example_CFLAGS = @CFLAGS_CHECKS@ -I $(top_srcdir)/include
-example_LDADD = @LDFLAGS_CHECKS@ $(top_builddir)/lib/libeconf.la
+example_CFLAGS = @CFLAGS_CHECKS@ @CFLAGS_WARNINGS@ -I $(top_srcdir)/include
+example_LDADD = @LDFLAGS_CHECKS@ @LDFLAGS_WARNINGS@ $(top_builddir)/lib/libeconf.la
 
 CLEANFILES = example

--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,21 @@ if test x"$enable_compiler_checks" = x"yes" ; then
    LDFLAGS_CHECKS="-fsanitize=address"
 fi
 
+dnl enable additional compiler warnings
+AC_ARG_ENABLE([compiler-warnings],
+    AS_HELP_STRING([--enable-compiler-warnings],[enables additional compiler warnings]))
+
+if test x"$enable_compiler_warnings" = x"yes" ; then
+   if test x"$enable_compiler_checks" = x"yes" ; then
+      AC_MSG_ERROR([Conflicting options: --enable-compiler-warnings cannot be used together with --eanble-compiler-checks])  
+   fi
+   CFLAGS_WARNINGS="-O2 -g -W -Wall -DXTSTRINGDEFINES -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=8 -Wbad-function-cast -Wcast-align -Wcast-qual -Winline -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef"
+   LDFLAGS_WARNINGS=""
+fi
 
 AC_SUBST(CFLAGS_CHECKS)
 AC_SUBST(LDFLAGS_CHECKS)
+AC_SUBST(CFLAGS_WARNINGS)
+AC_SUBST(LDFLAGS_WARNINGS)
 AC_CONFIG_FILES([Makefile lib/Makefile include/Makefile bin/Makefile tests/Makefile lib/libeconf.pc])
 AC_OUTPUT

--- a/example/example.c
+++ b/example/example.c
@@ -66,7 +66,7 @@ int main() {
   size_t key_number = 0;
   char **keys = econf_getKeys(key_file, "Basic Types", &key_number, NULL);
   printf("Keys: ");
-  for (int i = 0; i < key_number; i++) {
+  for (size_t i = 0; i < key_number; i++) {
     printf("%s, ", keys[i]);
   }
   puts("\n");

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,9 +1,9 @@
 lib_LTLIBRARIES = libeconf.la
 libeconf_la_SOURCES = ../src/libeconf.c ../src/getfilecontents.c ../src/mergefiles.c ../src/helpers.c ../src/keyfile.c ../src/econf_errString.c
-libeconf_la_CFLAGS = -D_REENTRANT=1 @CFLAGS_CHECKS@
+libeconf_la_CFLAGS = -D_REENTRANT=1 @CFLAGS_CHECKS@ @CFLAGS_WARNINGS@
 libeconf_la_CPPFLAGS = -I$(top_srcdir)/include
-libeconf_la_LDFLAGS = @LDFLAGS_CHECKS@ -version-info 0:0:0 \
-	-Wl,--no-undefined \
+libeconf_la_LDFLAGS = @LDFLAGS_CHECKS@ @CFLAGS_WARNINGS@ \
+	-version-info 0:0:0 -Wl,--no-undefined \
 	-Wl,--version-script=$(top_srcdir)/lib/libeconf.map
 libeconf_la_LIBADD = -lm
 

--- a/src/getfilecontents.c
+++ b/src/getfilecontents.c
@@ -41,7 +41,7 @@ fill_key_file(Key_File *read_file, FILE *kf, const char *delim) {
   // is allocated
   const size_t LLEN = 8;
   size_t file_length = 0, lnum = KEY_FILE_DEFAULT_LENGTH, llen = LLEN, vlen = 0;
-  char ch;
+  size_t ch;
 
   // Allocate memory for the Key_File based on KEY_FILE_DEFAULT_LENGTH
   struct file_entry *fe = malloc(KEY_FILE_DEFAULT_LENGTH * sizeof(struct file_entry));
@@ -107,12 +107,12 @@ fill_key_file(Key_File *read_file, FILE *kf, const char *delim) {
   free(buffer);
   // Check if the file is really at its end after EOF is encountered.
   if (!feof(kf)) {
-    read_file->length = -EBADF;
     return ECONF_ERROR;
   }
   if (!strcmp(fe->key, KEY_FILE_NULL_VALUE)) {
     fe->key = NULL;
     free(fe->group);
+    return ECONF_ERROR;
   }
   read_file->length = file_length;
   read_file->alloc_length = file_length;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -147,7 +147,7 @@ size_t find_key(Key_File key_file, const char *group, const char *key, econf_err
     free(grp);
     return -1;
   }
-  for (int i = 0; i < key_file.length; i++) {
+  for (size_t i = 0; i < key_file.length; i++) {
     if (!strcmp(key_file.file_entry[i].group, grp) &&
         !strcmp(key_file.file_entry[i].key, key)) {
       free(grp);

--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -151,7 +151,7 @@ Key_File *econf_merge_key_files(Key_File *usr_file, Key_File *etc_file, econf_er
 Key_File *econf_get_conf_from_dirs(const char *usr_conf_dir,
                                    const char *etc_conf_dir,
                                    const char *project_name,
-				   const char *config_suffix,
+                                   const char *config_suffix,
                                    const char *delim, char comment,
                                    econf_err *error) {
   size_t size = 1;
@@ -209,7 +209,7 @@ Key_File *econf_get_conf_from_dirs(const char *usr_conf_dir,
       key_files[size - 1] = key_file;
       Key_File **tmp = realloc(key_files, ++size * sizeof(Key_File *));
       if (!tmp) {
-        for (int i = 0; i < size - 1; i++) free(key_files[i]);
+        for (size_t i = 0; i < size - 1; i++) free(key_files[i]);
         free(key_files);
         if (error) *error = ECONF_NOMEM;
         return NULL;
@@ -281,7 +281,7 @@ void econf_write_key_file(Key_File *key_file, const char *save_to_dir,
   }
 
   // Write to file
-  for (int i = 0; i < key_file->length; i++) {
+  for (size_t i = 0; i < key_file->length; i++) {
     if (!i || strcmp(key_file->file_entry[i - 1].group,
                      key_file->file_entry[i].group)) {
       if (i)
@@ -315,7 +315,7 @@ char **econf_getGroups(Key_File *kf, size_t *length, econf_err *error) {
     if (error) *error = ECONF_NOMEM;
     return NULL;
   }
-  for (int i = 0; i < kf->length; i++) {
+  for (size_t i = 0; i < kf->length; i++) {
     if ((!i || strcmp(kf->file_entry[i].group, kf->file_entry[i - 1].group)) &&
         strcmp(kf->file_entry[i].group, KEY_FILE_NULL_VALUE)) {
       uniques[i] = 1;
@@ -329,7 +329,7 @@ char **econf_getGroups(Key_File *kf, size_t *length, econf_err *error) {
     return NULL;
   }
   tmp = 0;
-  for(int i = 0; i < kf->length; i++) {
+  for (size_t i = 0; i < kf->length; i++) {
     if (uniques[i]) { groups[tmp++] = strdup(kf->file_entry[i].group); }
   }
 
@@ -359,7 +359,7 @@ char **econf_getKeys(Key_File *kf, const char *grp, size_t *length, econf_err *e
     if (error) *error = ECONF_NOMEM;
     return NULL;
   }
-  for (int i = 0; i < kf->length; i++) {
+  for (size_t i = 0; i < kf->length; i++) {
     if (!strcmp(kf->file_entry[i].group, group) &&
         (!i || strcmp(kf->file_entry[i].key, kf->file_entry[i - 1].key))) {
       uniques[i] = 1;
@@ -374,7 +374,7 @@ char **econf_getKeys(Key_File *kf, const char *grp, size_t *length, econf_err *e
     free (uniques);
     return NULL;
   }
-  for(int i = 0, tmp = 0; i < kf->length; i++) {
+  for (size_t i = 0, tmp = 0; i < kf->length; i++) {
     if (uniques[i]) { keys[tmp++] = strdup(kf->file_entry[i].key); }
   }
 
@@ -444,7 +444,7 @@ void econf_char_a_destroy(char** array) {
 // Free memory allocated by key_file
 void econf_Key_File_destroy(Key_File *key_file) {
   if (!key_file) { return; }
-  for (int i = 0; i < key_file->alloc_length; i++) {
+  for (size_t i = 0; i < key_file->alloc_length; i++) {
     free(key_file->file_entry[i].group);
     free(key_file->file_entry[i].key);
     free(key_file->file_entry[i].value);

--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -90,9 +90,11 @@ Key_File *econf_get_key_file(const char *file_name, const char *delim,
   }
 
   read_file->comment = comment;
+  read_file->length = 0;
+  read_file->alloc_length = 0;
+  read_file->on_merge_delete = 0;
 
   t_err = fill_key_file(read_file, kf, delim);
-  read_file->on_merge_delete = 0;
   fclose(kf);
 
   if(t_err) {

--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -207,8 +207,14 @@ Key_File *econf_get_conf_from_dirs(const char *usr_conf_dir,
     if(key_file) {
       key_file->on_merge_delete = 1;
       key_files[size - 1] = key_file;
-      key_files = realloc(key_files, ++size * sizeof(Key_File *));
-      /* XXX ENOMEM check */
+      Key_File **tmp = realloc(key_files, ++size * sizeof(Key_File *));
+      if (!tmp) {
+        for (int i = 0; i < size - 1; i++) free(key_files[i]);
+        free(key_files);
+        if (error) *error = ECONF_NOMEM;
+        return NULL;
+      }
+      key_files = tmp;
     }
 
     // Indicate which directories to look for

--- a/src/mergefiles.c
+++ b/src/mergefiles.c
@@ -49,15 +49,15 @@ size_t merge_existing_groups(struct file_entry **fe, Key_File *uf, Key_File *ef,
                              const size_t etc_start) {
   char new_key;
   size_t merge_length = etc_start, tmp = etc_start, added_keys = etc_start;
-  for (int i = 0; i <= uf->length; i++) {
+  for (size_t i = 0; i <= uf->length; i++) {
     // Check if the group has changed in the last iteration
     if (i == uf->length ||
         (i && strcmp(uf->file_entry[i].group, uf->file_entry[i - 1].group))) {
-      for (int j = etc_start; j < ef->length; j++) {
+      for (size_t j = etc_start; j < ef->length; j++) {
         // Check for matching groups
         if (!strcmp(uf->file_entry[i - 1].group, ef->file_entry[j].group)) {
           new_key = 1;
-          for (int k = merge_length; k < i + tmp; k++) {
+          for (size_t k = merge_length; k < i + tmp; k++) {
             // If an existing key is found in ef take the value from ef
             if (!strcmp((*fe)[k].key, ef->file_entry[j].key)) {
               free((*fe)[k].value);
@@ -86,11 +86,11 @@ size_t add_new_groups(struct file_entry **fe, Key_File *uf, Key_File *ef,
                       const size_t merge_length) {
   size_t added_keys = merge_length;
   char new_key;
-  for (int i = 0; i < ef->length; i++) {
+  for (size_t i = 0; i < ef->length; i++) {
     if (!strcmp(ef->file_entry[i].group, KEY_FILE_NULL_VALUE))
       continue;
     new_key = 1;
-    for (int j = 0; j < uf->length; j++) {
+    for (size_t j = 0; j < uf->length; j++) {
       if (!strcmp(uf->file_entry[j].group, ef->file_entry[i].group)) {
         new_key = 0;
         break;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 
-AM_CFLAGS = @CFLAGS_CHECKS@ -I$(top_srcdir)/include -DTESTSDIR=\"$(top_srcdir)/tests/\"
-LDADD = @LDFLAGS_CHECKS@ $(top_builddir)/lib/libeconf.la
+AM_CFLAGS = @CFLAGS_CHECKS@ @CFLAGS_WARNINGS@ -I$(top_srcdir)/include -DTESTSDIR=\"$(top_srcdir)/tests/\"
+LDADD = @LDFLAGS_CHECKS@ @LDFLAGS_WARNINGS@ $(top_builddir)/lib/libeconf.la
 
 CLEANFILES = *~
 

--- a/tests/tst-logindefs1.c
+++ b/tests/tst-logindefs1.c
@@ -76,9 +76,9 @@ main(int argc, char **argv)
       fprintf (stderr, "No keys found?\n");
       return 1;
     }
-  for (int i = 0; i < key_number; i++)
+  for (size_t i = 0; i < key_number; i++)
     {
-      printf ("%i: %s\n", i, keys[i]);
+      printf ("%li: %s\n", i, keys[i]);
     }
 
   econf_destroy (keys);


### PR DESCRIPTION
`getc` returns an int thus `0xFF` and `EOF` would both result in `-1`
when using a char to get the return value.
Make sure `length` and `alloc_length` always result in 0 on failure to
read a file.

Fixes: #60 
Fixes: #61
Signed-off-by: Pascal Arlt <parlt@suse.com>