### PR TITLE
Add test case for reading login.defs with data from util-linux testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tests/tst-arguments3
 tests/tst-arguments4
 tests/tst-arguments5
 tests/tst-logindefs1
+tests/tst-logindefs2
 tests/tst-getconfdirs1
 tests/tst-getconfdirs2
 tests/tst-getconfdirs3

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,12 +4,14 @@ LDADD = @LDFLAGS_CHECKS@ @LDFLAGS_WARNINGS@ $(top_builddir)/lib/libeconf.la
 
 CLEANFILES = *~
 
-EXTRA_DIST = tst-arguments-data tst-logindefs1-data tst-merge1-data \
-	tst-merge2-data tst-getconfdirs1-data tst-getconfdirs3-data \
+EXTRA_DIST = tst-arguments-data tst-logindefs1-data tst-logindefs2-data \
+	tst-merge1-data tst-merge2-data \
+	tst-getconfdirs1-data tst-getconfdirs3-data \
 	tst-getconfdirs4-data tst-getconfdirs5-data tst-getconfdirs6-data \
 	tst-arguments5-data tst-groups3-data tst-parseconfig-data
 
-TESTS = tst-filedoesnotexit1 tst-merge1 tst-merge2 tst-logindefs1 \
+TESTS = tst-filedoesnotexit1 tst-merge1 tst-merge2 \
+	tst-logindefs1 tst-logindefs2 \
 	tst-arguments1 tst-arguments2 tst-arguments3 tst-arguments4 \
 	tst-arguments5 \
 	tst-getconfdirs1 tst-getconfdirs2 tst-getconfdirs3 \
@@ -19,7 +21,7 @@ TESTS = tst-filedoesnotexit1 tst-merge1 tst-merge2 tst-logindefs1 \
 	tst-groups1 tst-groups2 tst-groups3 tst-groups4 \
 	tst-parseconfig1
 
-XFAIL_TESTS = tst-groups3 tst-parseconfig1
+XFAIL_TESTS = tst-groups3 tst-parseconfig1 tst-logindefs2
 
 check_PROGRAMS = ${TESTS}
 

--- a/tests/tst-logindefs2-data/logindefs.data
+++ b/tests/tst-logindefs2-data/logindefs.data
@@ -1,0 +1,16 @@
+#
+# this is /etc/login.defs sample
+#
+
+HELLO_WORLD	"hello world!"
+STRING		this_is_string		# another comment
+NUMBER		123456
+BOOLEAN		yEs
+
+CRAZY1 = "this is crazy format"
+CRAZY2=fooBar
+CRAZY3    FoooBaaar
+
+EMPTY
+
+END	"the is end"

--- a/tests/tst-logindefs2.c
+++ b/tests/tst-logindefs2.c
@@ -1,0 +1,88 @@
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "libeconf.h"
+
+/* Test case:
+   Open default logindefs.data from util-linux and try out if we can read
+   all entries
+*/
+
+int
+main(void)
+{
+  econf_file *key_file;
+  char **keys;
+  size_t key_number;
+  econf_err error;
+
+  if ((error = econf_readFile (&key_file, TESTSDIR"tst-logindefs2-data/logindefs.data", "= \t", "#")))
+    {
+      fprintf (stderr, "ERROR: couldn't read configuration file: %s\n", econf_errString(error));
+      return 1;
+    }
+
+  if ((error = econf_getKeys(key_file, NULL, &key_number, &keys)))
+    {
+      fprintf (stderr, "Error getting all keys: %s\n", econf_errString(error));
+      return 1;
+    }
+  if (key_number == 0)
+    {
+      fprintf (stderr, "No keys found?\n");
+      return 1;
+    }
+  for (size_t i = 0; i < key_number; i++)
+    {
+      char *value;
+      econf_getStringValue(key_file, NULL, keys[i], &value);
+      printf ("%lu: %s: '%s'\n", i, keys[i], value);
+    }
+
+  int retval = 0;
+  char *strval = NULL;
+  econf_getStringValue (key_file, NULL, "STRING", &strval);
+  if (strval == NULL || strcmp (strval, "this_is_string") != 0)
+    {
+      fprintf (stderr, "ERROR: %s, expected: %s, got: '%s'\n",
+	       "STRING", "this_is_string", strval);
+      retval = 1;
+    }
+
+  int intval = 0;
+  econf_getIntValue (key_file, NULL, "NUMBER", &intval);
+  if (intval == 0 || intval != 123456)
+    {
+      fprintf (stderr, "ERROR: %s, expected: %i, got: %i\n",
+	       "NUMBER", 123456, intval);
+      retval = 1;
+    }
+
+  bool boolval = false;
+  econf_getBoolValue (key_file, NULL, "BOOLEAN", &boolval);
+  if (boolval != true)
+    {
+      fprintf (stderr, "ERROR: %s, expected: %i, got: %i\n",
+	       "BOOLEAN", true, boolval);
+      retval = 1;
+    }
+
+  strval = NULL;
+  econf_getStringValue (key_file, NULL, "EMPTY", &strval);
+  if (strval == NULL || strcmp (strval, "") != 0)
+    {
+      fprintf (stderr, "ERROR: %s, expected: '%s', got: '%s'\n",
+	       "EMPTY", "", strval);
+      retval = 1;
+    }
+
+  econf_free (keys);
+  econf_free (key_file);
+
+  return retval;
+}


### PR DESCRIPTION
This test is currently failing due to some deficits of our parser (like handling empty keys as groups).