### PR TITLE
Implement econf_get*ValueDef functions: if key is not found, a provided

### DIFF
--- a/include/libeconf.h
+++ b/include/libeconf.h
@@ -112,6 +112,17 @@ extern econf_err econf_getDoubleValue(econf_file *kf, const char *group, const c
 extern econf_err econf_getStringValue(econf_file *kf, const char *group, const char *key, char **result);
 extern econf_err econf_getBoolValue(econf_file *kf, const char *group, const char *key, bool *result);
 
+/* If key is not found, the default value is returned and error is ECONF_NOKEY */
+extern econf_err econf_getIntValueDef(econf_file *kf, const char *group, const char *key, int32_t *result, int32_t def);
+extern econf_err econf_getInt64ValueDef(econf_file *kf, const char *group, const char *key, int64_t *result, int64_t def);
+extern econf_err econf_getUIntValueDef(econf_file *kf, const char *group, const char *key, uint32_t *result, uint32_t def);
+extern econf_err econf_getUInt64ValueDef(econf_file *kf, const char *group, const char *key, uint64_t *result, uint64_t def);
+extern econf_err econf_getFloatValueDef(econf_file *kf, const char *group, const char *key, float *result, float def);
+extern econf_err econf_getDoubleValueDef(econf_file *kf, const char *group, const char *key, double *result, double def);
+/* Returns a newly allocated string, even if "default" is returned. */
+extern econf_err econf_getStringValueDef(econf_file *kf, const char *group, const char *key, char **result, char *def);
+extern econf_err econf_getBoolValueDef(econf_file *kf, const char *group, const char *key, bool *result, bool def);
+
 /* --- SETTERS --- */
 
 extern econf_err econf_setIntValue(econf_file *kf, const char *group, const char *key, int32_t value);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES = libeconf.la
-libeconf_la_SOURCES = ../src/libeconf.c ../src/getfilecontents.c ../src/mergefiles.c ../src/helpers.c ../src/keyfile.c ../src/econf_errString.c
+libeconf_la_SOURCES = ../src/libeconf.c ../src/getfilecontents.c ../src/mergefiles.c ../src/helpers.c ../src/keyfile.c ../src/econf_errString.c ../src/get_value_def.c
 libeconf_la_CFLAGS = -D_REENTRANT=1 @CFLAGS_CHECKS@ @CFLAGS_WARNINGS@
 libeconf_la_CPPFLAGS = -I$(top_srcdir)/include
 libeconf_la_LDFLAGS = @LDFLAGS_CHECKS@ @CFLAGS_WARNINGS@ \

--- a/lib/libeconf.map
+++ b/lib/libeconf.map
@@ -33,3 +33,16 @@ LIBECONF_ALPHA {
     econf_newKeyFile;
     econf_writeFile;
 } LIBECONF_0.2;
+LIBECONF_0.3 {
+  global:
+    econf_getBoolValueDef;
+    econf_getDoubleValueDef;
+    econf_getFloatValueDef;
+    econf_getGroupsDef;
+    econf_getInt64ValueDef;
+    econf_getIntValueDef;
+    econf_getKeysDef;
+    econf_getStringValueDef;
+    econf_getUInt64ValueDef;
+    econf_getUIntValueDef;
+} LIBECONF_0.2;

--- a/src/get_value_def.c
+++ b/src/get_value_def.c
@@ -1,0 +1,51 @@
+/*
+  Copyright (C) 2019 SUSE LLC
+  Author: Thorsten Kukuk <kukuk@suse.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include "libeconf.h"
+
+#define econf_getValueDef(FCT_TYPE, TYPE, STRDUP)				\
+econf_err econf_get ## FCT_TYPE ## ValueDef(econf_file *ef, const char *group, \
+					     const char *key, TYPE *result, TYPE def) { \
+  if (!ef) \
+    return ECONF_ERROR; \
+\
+  econf_err error = econf_get ## FCT_TYPE ## Value(ef, group, key, result);	\
+  if (error == ECONF_NOKEY) \
+    *result = STRDUP(def);  \
+  return error; \
+}
+
+
+econf_getValueDef(Int, int32_t, )
+econf_getValueDef(Int64, int64_t, )
+econf_getValueDef(UInt, uint32_t, )
+econf_getValueDef(UInt64, uint64_t, )
+econf_getValueDef(Float, float, )
+econf_getValueDef(Double, double, )
+econf_getValueDef(String, char *, strdup)
+econf_getValueDef(Bool, bool, )


### PR DESCRIPTION
default is returned.