### PR TITLE
Ensure LICENSE, README, and TODO are included in the release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,3 +5,5 @@ SUBDIRS = lib include bin tests
 ACLOCAL_AMFLAGS = -I m4
 
 CLEANFILES = *~
+
+EXTRA_DIST = LICENSE README.md TODO.md


### PR DESCRIPTION
This is required for packaging libeconf in Fedora.