### PR TITLE
Reset *key_file to NULL after free

### DIFF
--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -98,6 +98,7 @@ econf_err econf_readFile(econf_file **key_file, const char *file_name,
 
   if(t_err) {
     econf_free(*key_file);
+    *key_file = NULL;
     return t_err;
   }
 


### PR DESCRIPTION
To resolve #110 , tested locally with reproduction case, no other use-after-free case found (at least none using the econf_free function)