### PR TITLE
Move C++ ABI compatibility section

### DIFF
--- a/include/libeconf.h
+++ b/include/libeconf.h
@@ -25,13 +25,13 @@
 
 /* libeconf.h */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Public API for the econf library */
 


### PR DESCRIPTION
The C ABI marker section for C++ compilers should not
include the standard headers as we are only need this
for our API, not the standard library.