### PR TITLE
Fix typo in README.md: serveral -> several

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ two methods of overriding this vendor settings: copy the file from
 directory named _file_._suffix_.d/ within /etc can be created, with
 drop-in files in the form _name_._suffix_. This files contain only the
 changes of the specific settings the user is interested in. There can
-be serveral such drop-in files, they are processed in lexicographic order
+be several such drop-in files, they are processed in lexicographic order
 of their filename.
 
 


### PR DESCRIPTION
The debian package linter spotted this typo (in the package description
which was copied from the initial part of the README):

W: libeconf-dev: spelling-error-in-description serveral several
N:
N:    Lintian found a spelling error in the package description. Lintian has a
N:    list of common misspellings that it looks for. It does not have a
N:    dictionary like a spelling checker does. It is particularly picky about
N:    spelling and capitalization in package descriptions since they're very
N:    visible to end users.
N:
N:    Severity: warning
N:
N:    Check: fields/description