### PR TITLE
Covscan issues

### DIFF
--- a/lib/helpers.c
+++ b/lib/helpers.c
@@ -106,6 +106,8 @@ char *addbrackets(const char *string) {
   size_t length = strlen(string);
   if (!(*string == '[' && string[length - 1] == ']')) {
     char *buffer = malloc(length + 3);
+    if (buffer == NULL)
+      return NULL;
     char *cp = buffer;
     *cp++ = '[';
     cp = stpcpy (cp, string);

--- a/lib/helpers.c
+++ b/lib/helpers.c
@@ -226,5 +226,6 @@ struct file_entry cpy_file_entry(struct file_entry fe) {
     copied_fe.comment_after_value = strdup(fe.comment_after_value);
   else
     copied_fe.comment_after_value = NULL;  
+  copied_fe.line_number = 0;
   return copied_fe;
 }

--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -241,8 +241,10 @@ econf_err econf_readDirsHistory(econf_file ***key_files,
   /* create space to store the econf_files for merging */
   *size = *size+1;
   *key_files = calloc(*size, sizeof(econf_file*));
-  if (*key_files == NULL)
+  if (*key_files == NULL) {
+    econf_freeFile(key_file);
     return ECONF_NOMEM;
+  }
 
   if (*size == 2) {
     key_file->on_merge_delete = 1;
@@ -343,8 +345,10 @@ econf_err econf_writeFile(econf_file *key_file, const char *save_to_dir,
     return ECONF_NOMEM;
 
   FILE *kf = fopen(save_to, "w");
-  if (kf == NULL)
+  if (kf == NULL) {
+    free(save_to);
     return ECONF_WRITEERROR;
+  }
 
   // Write to file
   for (size_t i = 0; i < key_file->length; i++) {
@@ -401,8 +405,10 @@ econf_getGroups(econf_file *kf, size_t *length, char ***groups)
     return ECONF_NOGROUP;
   }
   *groups = calloc(tmp + 1, sizeof(char*));
-  if (*groups == NULL)
+  if (*groups == NULL) {
+    free(uniques);
     return ECONF_NOMEM;
+  }
 
   tmp = 0;
   for (size_t i = 0; i < kf->length; i++)


### PR DESCRIPTION
Fixes for several covscan issues:
Error: RESOURCE_LEAK (CWE-772): [#def1]
libeconf-0.3.8/lib/libeconf.c:205: alloc_arg: "econf_readFile" allocates memory that is stored into "key_file".
libeconf-0.3.8/lib/libeconf.c:237: leaked_storage: Variable "key_file" going out of scope leaks the storage it points to.
  235|     key_files = calloc((++size), sizeof(econf_file*));
  236|     if (key_files == NULL)
  237|->     return ECONF_NOMEM;
  238|
  239|     if (size == 2)

Error: RESOURCE_LEAK (CWE-772): [#def2]
libeconf-0.3.8/lib/libeconf.c:297: alloc_fn: Storage is returned from allocation function "combine_strings".
libeconf-0.3.8/lib/libeconf.c:297: var_assign: Assigning: "save_to" = storage returned from "combine_strings(save_to_dir, file_name, '/')".
libeconf-0.3.8/lib/libeconf.c:301: noescape: Resource "save_to" is not freed or pointed-to in "fopen".
libeconf-0.3.8/lib/libeconf.c:303: leaked_storage: Variable "save_to" going out of scope leaks the storage it points to.
  301|     FILE *kf = fopen(save_to, "w");
  302|     if (kf == NULL)
  303|->     return ECONF_WRITEERROR;
  304|
  305|     // Write to file

Error: RESOURCE_LEAK (CWE-772): [#def3]
libeconf-0.3.8/lib/libeconf.c:337: alloc_fn: Storage is returned from allocation function "calloc".
libeconf-0.3.8/lib/libeconf.c:337: var_assign: Assigning: "uniques" = storage returned from "calloc(kf->length, 1UL)".
libeconf-0.3.8/lib/libeconf.c:354: leaked_storage: Variable "uniques" going out of scope leaks the storage it points to.
  352|     *groups = calloc(tmp + 1, sizeof(char*));
  353|     if (*groups == NULL)
  354|->     return ECONF_NOMEM;
  355|
  356|     tmp = 0;

Error: GCC_ANALYZER_WARNING (CWE-476): [#def5]
libeconf-0.3.8/lib/helpers.c: scope_hint: In function 'addbrackets'
libeconf-0.3.8/lib/helpers.c:108:11: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'buffer'
  106|       char *buffer = malloc(length + 3);
  107|       char *cp = buffer;
  108|->     *cp++ = '[';
  109|       cp = stpcpy (cp, string);
  110|       *cp++ = ']';

Error: UNINIT (CWE-457): [#def6]
libeconf-0.3.8/lib/helpers.c:210: var_decl: Declaring variable "copied_fe" without initializer.
libeconf-0.3.8/lib/helpers.c:217: uninit_use: Using uninitialized value "copied_fe". Field "copied_fe.line_number" is uninitialized.
  215|     else
  216|       copied_fe.value = NULL;
  217|->   return copied_fe;
  218|   }