### PR TITLE
libeconf.h: add missing sys/types.h header

### DIFF
--- a/include/libeconf.h
+++ b/include/libeconf.h
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
required for mode_t, gid_t, uid_t