### PR TITLE
Fix test

### DIFF
--- a/tests/tst-shells1.c
+++ b/tests/tst-shells1.c
@@ -119,6 +119,7 @@ main(void)
 
   econf_free (keys);
   econf_free (key_file);
+  econf_free (key_compare);
 
   return 0;
 }


### PR DESCRIPTION
Free key_compare, otherwise the test fails if compiled with address sanitizer.