### PR TITLE
Plug memory leak

### DIFF
--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -430,9 +430,11 @@ econf_err econf_readDirsHistoryWithCallback(econf_file ***key_files,
   (*key_files)[*size] = NULL;
   econf_freeArray(configure_dirs);
   if (*size <= 0)
+  {
+    free(*key_files);
     return ECONF_NOFILE;
-  else
-    return ECONF_SUCCESS;
+  }
+  return ECONF_SUCCESS;
 }
 
 econf_err econf_readDirsHistory(econf_file ***key_files,

--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -421,6 +421,7 @@ econf_err econf_readDirsHistoryWithCallback(econf_file ***key_files,
 	econf_freeFile((*key_files)[k]);
       }
       free(*key_files);
+      *key_files = NULL;
       econf_freeArray(configure_dirs);
       return error;
     }
@@ -432,6 +433,7 @@ econf_err econf_readDirsHistoryWithCallback(econf_file ***key_files,
   if (*size <= 0)
   {
     free(*key_files);
+    *key_files = NULL;
     return ECONF_NOFILE;
   }
   return ECONF_SUCCESS;


### PR DESCRIPTION
The function `econf_readDirsHistoryWithCallback` leaks memory if no file is found.

If libeconf is compiled with address sanitizer, you can reproduce this with `econftool` by calling it with non-existing files, e.g. `econftool show non.existing`.