### PR TITLE
Improve data quote check in read_file

### DIFF
--- a/lib/getfilecontents.c
+++ b/lib/getfilecontents.c
@@ -499,7 +499,7 @@ read_file(econf_file *ef, const char *file,
 	else
 	  data--;
       }
-      if (*(p + 1) != '\0')
+      if (*p != '\0' && *(p + 1) != '\0')
 	*(p + 1) = '\0';
     }
 


### PR DESCRIPTION
Mentioned below as well: This is a purely defensive measure. NO real bug exists!

If a file ends with a double quote character (") without a newline and this double quote is interpreted as start of data, then an access after the last NUL byte which was written by fgets could happen.

This happens because data, after *data == '"' is true, is incremented. It would point to the NUL byte. Since strlen(data) is 0, the pointer p will point at data, i.e. fgets' NUL byte. The next while loops won't apply, because p is not larger than data.

The if-block itself leads to a decrement of data (correct). But after that, "p + 1" is checked. This access goes beyond the NUL byte of fgets, since "p" itself already points to that NUL byte.

Since fgets won't write into the complete array, this is currently no issue. It could become an issue though if fgets is replaced with getline in the future.

With this correction in place, fgets can fully write into BUFSIZ without triggering such an out of boundary access.