### PR TITLE
Fix static analyzer detected issues

### DIFF
--- a/lib/libeconf_ext.c
+++ b/lib/libeconf_ext.c
@@ -90,15 +90,19 @@ econf_getExtValue(econf_file *kf, const char *group,
     {
       /* one quoted string only */
       (*result)->values = realloc ((*result)->values, sizeof (char*) * ++n_del);
-      if ((*result)->values == NULL)
+      if ((*result)->values == NULL) {
+        econf_freeExtValue(*result);
         return ECONF_NOMEM; /* memory allocation failed */
+      }
       (*result)->values[n_del-1] = strdup(value_string);
     } else {
       /* splitting into a character array */
       while ((line = strsep(&value_string, "\n")) != NULL) {
         (*result)->values = realloc ((*result)->values, sizeof (char*) * ++n_del);
-        if ((*result)->values == NULL)
+        if ((*result)->values == NULL) {
+          econf_freeExtValue(*result);
           return ECONF_NOMEM; /* memory allocation failed */
+        }
         (*result)->values[n_del-1] = strdup(trim(line));
       }
     }

--- a/lib/readconfig.c
+++ b/lib/readconfig.c
@@ -29,7 +29,7 @@ econf_err readConfigHistoryWithCallback(econf_file ***key_files,
 {
   const char *suffix, *default_dirs[4] = {NULL, NULL, NULL, NULL};
   char *distfile, *runfile, *etcfile, *cp;
-  econf_file *key_file;
+  econf_file *key_file = NULL;
   econf_err error;
 
   *size = 0;

--- a/lib/readconfig.c
+++ b/lib/readconfig.c
@@ -162,14 +162,19 @@ econf_err readConfigHistoryWithCallback(econf_file ***key_files,
   char **configure_dirs = malloc(sizeof(char *) * (conf_count + 2));
   if (configure_dirs == NULL)
   {
+    free(*key_files);
+    *key_files = NULL;
     return ECONF_NOMEM;
   }
 
   if (conf_count == 0)
   {
     char *suffix_d = malloc (strlen(suffix) + 4); /* + strlen(".d/") */
-    if (suffix_d == NULL)
+    if (suffix_d == NULL) {
+      free(*key_files);
+      *key_files = NULL;
       return ECONF_NOMEM;
+    }
     cp = stpcpy(suffix_d, suffix);
     stpcpy(cp, ".d");
     configure_dirs[0] = suffix_d;


### PR DESCRIPTION
# Resource leaks
```
Error: RESOURCE_LEAK (CWE-772):

libeconf-0.4.1/util/econftool.c:185: alloc_arg: "econf_getExtValue" allocates memory that is stored into "value".
libeconf-0.4.1/util/econftool.c:189: leaked_storage: Variable "value" going out of scope leaks the storage it points to.
187| fprintf(stderr, "%d: %s\n", econf_error, econf_errString(econf_error));
188| econf_free(keys);
189|-> return econf_error;
190| }
191| if (value != NULL) {
```

```
Error: RESOURCE_LEAK (CWE-772):
libeconf-0.4.1/lib/libeconf.c:312: alloc_arg: "econf_readDirsHistory" allocates memory that is stored into "key_files".
libeconf-0.4.1/lib/libeconf.c:321: leaked_storage: Variable "key_files" going out of scope leaks the storage it points to.
319| comment);
320| if (error != ECONF_SUCCESS)
321|-> return error;
322|
323| // Merge the list of acquired key_files into merged_file
```

# Uninitialized variables
```
Error: UNINIT (CWE-457):
libeconf-0.4.1/lib/libeconf.c:161: var_decl: Declaring variable "key_file" without initializer.
libeconf-0.4.1/lib/libeconf.c:247: uninit_use_in_call: Using uninitialized value "key_file" when calling "econf_freeFile".
245|     *key_files = calloc(*size, sizeof(econf_file*));
246|     if (*key_files == NULL) {
247|->     econf_freeFile(key_file);
248|       return ECONF_NOMEM;
249|     }
```