### PR TITLE
Fix build with musl libc on ppc64le

### DIFF
--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -31,6 +31,7 @@
 #include "readconfig.h"
 
 #include <libgen.h>
+#include <limits.h>
 #include <dirent.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
PATH_MAX is defined in limits.h in POSIX.

Fixes https://github.com/openSUSE/libeconf/issues/197

ref: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html