### PR TITLE
tst-comments2: comment sign in quoted string

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -60,6 +60,11 @@ tst_extvalue_exe = executable('tst-extvalue', 'tst-extvalue.c', c_args: test_arg
 test('tst-extvalue', tst_extvalue_exe)
 tst_comments_exe = executable('tst-comments', 'tst-comments.c', c_args: test_args, dependencies : libeconf_dep)
 test('tst-comments', tst_comments_exe)
+tst_comments2_exe = executable('tst-comments2',
+  sources: ['tst-comments2.c', '../lib/helpers.c', '../lib/readconfig.c', '../lib/libeconf.c', '../lib/getfilecontents.c',
+            '../lib/mergefiles.c', '../lib/econf_error.c', '../lib/keyfile.c'],
+  c_args: ['-DTESTSDIR="' + testdir + 'tst-comments2-data' + '"'], dependencies : staticlibeconf_dep)
+test('tst-comments2', tst_comments2_exe)
 
 tst_getconfdirs1_exe = executable('tst-getconfdirs1', 'tst-getconfdirs1.c', c_args: ['-DSUFFIX=".conf"', test_args], dependencies : libeconf_dep)
 test('tst-getconfdirs1', tst_getconfdirs1_exe)

--- a/tests/tst-comments2-data/env.conf
+++ b/tests/tst-comments2-data/env.conf
@@ -1,0 +1,3 @@
+KEY1="a#b"
+KEY2="a#b" # with real comment
+KEY3=a#b

--- a/tests/tst-comments2.c
+++ b/tests/tst-comments2.c
@@ -1,0 +1,75 @@
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#include "libeconf.h"
+
+/* Test case:
+
+   variable contains comment character in a quoted string
+
+*/
+
+static int
+check_key(econf_file *key_file, char *key, char *expected_val)
+{
+  char *val = NULL;
+  econf_err error = econf_getStringValue (key_file, "", key, &val);
+  if (expected_val == NULL)
+    {
+      if (val == NULL)
+	return 0;
+
+      fprintf (stderr, "ERROR: %s has value \"%s\"\n", key, val);
+      return 1;
+    }
+  if (val == NULL || strlen(val) == 0)
+    {
+      fprintf (stderr, "ERROR: %s returns nothing! (%s)\n", key,
+	       econf_errString(error));
+      return 1;
+    }
+  if (strcmp (val, expected_val) != 0)
+    {
+      fprintf (stderr, "ERROR: %s is not \"%s\", got [%s]\n", key, expected_val, val);
+      return 1;
+    }
+
+  printf("Ok: %s=%s\n", key, val);
+  free (val);
+  return 0;
+}
+
+int
+main(void)
+{
+  econf_file *key_file = NULL;
+  int retval = 0;
+  econf_err error;
+
+  error = econf_readConfig (&key_file,
+	                    NULL,
+                            "",
+			    "env",
+			    "conf", "=", "#");
+  if (error)
+    {
+      fprintf (stderr, "ERROR: econf_readConfig: %s\n",
+	       econf_errString(error));
+      return 1;
+    }
+
+  if (check_key(key_file, "KEY1", "a#b") != 0)
+    retval = 1;
+  if (check_key(key_file, "KEY2", "a#b") != 0)
+    retval = 1;
+  if (check_key(key_file, "KEY3", "a") != 0)
+    retval = 1;
+
+  econf_free (key_file);
+
+  return retval;
+}


### PR DESCRIPTION
The comment character (e.g. '#') in a quoted string should not be handled as comment but as part of the value.
See https://github.com/linux-pam/linux-pam/issues/13