### PR TITLE
Remove unused functions and reduce variable visibility

### DIFF
--- a/lib/helpers.c
+++ b/lib/helpers.c
@@ -50,28 +50,6 @@ void initialize(econf_file *key_file, size_t num) {
   key_file->file_entry[num].quotes = false;
 }
 
-// Remove whitespace from beginning and end, append string terminator
-char *clearblank(size_t *vlen, char *string) {
-  if (!*vlen) return string;
-
-  char *buffer = string, *ptr = string;
-  string[*vlen] = 0;
-
-  while (*string != 0) {
-    if (ptr == buffer && (*string == ' ' || *string == '\t')) {
-      (*vlen)--;
-    } else {
-      *ptr++ = *string;
-    }
-    string++;
-  }
-  while (buffer[*vlen - 1] == ' ' || buffer[*vlen - 1] == '\t')
-    (*vlen)--;
-
-  buffer[*vlen] = 0;
-  return buffer;
-}
-
 char *get_absolute_path(const char *path, econf_err *error) {
   char *absolute_path;
   if(*path != '/') {

--- a/lib/keyfile.c
+++ b/lib/keyfile.c
@@ -217,37 +217,6 @@ econf_err setKey(econf_file *key_file, size_t num, const char *value) {
   return ECONF_SUCCESS;
 }
 
-econf_err setComments(econf_file *key_file, size_t num,
-		      const char *comment_before_key,
-		      const char *comment_after_value) {
-  if (key_file == NULL)
-    return ECONF_ERROR;
-
-  if (key_file->file_entry[num].comment_before_key)
-    free(key_file->file_entry[num].comment_before_key);
-  if (comment_before_key)
-  {
-    key_file->file_entry[num].comment_before_key = strdup(comment_before_key);
-    if (key_file->file_entry[num].comment_before_key == NULL)
-      return ECONF_NOMEM;
-  } else {
-    key_file->file_entry[num].comment_before_key = NULL;
-  }
-
-  if (key_file->file_entry[num].comment_after_value)
-    free(key_file->file_entry[num].comment_after_value);
-  if (comment_after_value)
-  {
-    key_file->file_entry[num].comment_after_value = strdup(comment_after_value);
-    if (key_file->file_entry[num].comment_after_value == NULL)
-      return ECONF_NOMEM;
-  } else {
-    key_file->file_entry[num].comment_after_value = NULL;
-  }
-
-  return ECONF_SUCCESS;
-}
-
 #define econf_setValueNum(FCT_TYPE, TYPE, FMT, PR)			\
 econf_err set ## FCT_TYPE ## ValueNum(econf_file *ef, size_t num, const void *v) { \
   const TYPE *value = (const TYPE*) v; \

--- a/lib/keyfile.h
+++ b/lib/keyfile.h
@@ -109,10 +109,6 @@ econf_err getPath(econf_file key_file, char **path);
 econf_err setGroup(econf_file *key_file, size_t num, const char *value);
 /* Set the key of the file_entry element number num */
 econf_err setKey(econf_file *key_file, size_t num, const char *value);
-/* Set comments of the file_entry element number num */
-econf_err setComments(econf_file *key_file, size_t num,
-		      const char *comment_before_key,
-		      const char *comment_after_value);
 
 /* Functions used to set a value from key_file depending on num.
    Expects a void pointer to the value which is cast to the corresponding

--- a/lib/libeconf.c
+++ b/lib/libeconf.c
@@ -40,8 +40,8 @@
 #define CONFIG_DIRS "CONFIG_DIRS="
 
 // configuration directories format
-char **conf_dirs = {NULL}; // see econf_set_conf_dirs
-int conf_count = 0;
+static char **conf_dirs = {NULL}; // see econf_set_conf_dirs
+static int conf_count = 0;
 
 void econf_requireOwner(uid_t owner)
 {


### PR DESCRIPTION
I've put both commits into one pull request, since both technically reduce the accessible interface exposed through libeconf.

- The functions `clearblank` and `setComments` can be removed
- Avoid exposing two global variables, instead turn them into `static` ones