### PR TITLE
Remove undefined symbols from version script

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(econf PROPERTIES
   C_STANDARD 11
   C_STANDARD_REQUIRED ON
   PUBLIC_HEADER "${PROJECT_SOURCE_DIR}/include/libeconf.h;${PROJECT_SOURCE_DIR}/include/libeconf_ext.h"
-  LINK_FLAGS "-Wl,--no-undefined -Wl,--version-script,\"${PROJECT_SOURCE_DIR}/lib/libeconf.map\""
+  LINK_FLAGS "-Wl,--no-undefined -Wl,--no-undefined-version -Wl,--version-script,\"${PROJECT_SOURCE_DIR}/lib/libeconf.map\""
 )
 
 # Install the library

--- a/lib/libeconf.map
+++ b/lib/libeconf.map
@@ -38,10 +38,8 @@ LIBECONF_0.3 {
     econf_getBoolValueDef;
     econf_getDoubleValueDef;
     econf_getFloatValueDef;
-    econf_getGroupsDef;
     econf_getInt64ValueDef;
     econf_getIntValueDef;
-    econf_getKeysDef;
     econf_getStringValueDef;
     econf_getUInt64ValueDef;
     econf_getUIntValueDef;
@@ -68,9 +66,6 @@ LIBECONF_0.4 {
 } LIBECONF_0.3;
 LIBECONF_0.5 {
   global:
-    econf_readFileWithCallback;
-    econf_readDirsWithCallback;
-    econf_readDirsHistoryWithCallback;
     econf_set_conf_dirs;
 } LIBECONF_0.4;
 LIBECONF_0.6 {

--- a/meson.build
+++ b/meson.build
@@ -54,15 +54,20 @@ libeconf_src = files(
 example_src = ['example/example.c']
 econftool_src = ['util/econftool.c']
 
+possible_link_args = [
+      '-Wl,--no-undefined',
+      '-Wl,--no-undefined-version',
+      ]
+
 mapfile = 'lib/libeconf.map'
-version_flag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+version_flag = ['-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)]
 
 lib = library(
   'econf',
   libeconf_src,
   include_directories : inc,
   install : true,
-  link_args : version_flag,
+  link_args : cc.get_supported_link_arguments(possible_link_args) + version_flag,
   link_depends : mapfile,
   version : meson.project_version(),
   soversion : '0',


### PR DESCRIPTION
Resolves the following lld link errors/warnings:

```
ld.lld: error: version script assignment of 'LIBECONF_0.3' to symbol 'econf_getGroupsDef' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBECONF_0.3' to symbol 'econf_getKeysDef' failed: symbol not defined
ld.lld: warning: attempt to reassign symbol 'econf_readFileWithCallback' of version 'LIBECONF_0.4' to version 'LIBECONF_0.5'
ld.lld: warning: attempt to reassign symbol 'econf_readDirsWithCallback' of version 'LIBECONF_0.4' to version 'LIBECONF_0.5'
ld.lld: warning: attempt to reassign symbol 'econf_readDirsHistoryWithCallback' of version 'LIBECONF_0.4' to version 'LIBECONF_0.5'
```

Also add linker flags to prevent future errors/warnings from making it into the code base.