### PR TITLE
Remove static library declaration from meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,11 +77,6 @@ pkg.generate(
   version : meson.project_version(),
 )
 
-libeconf_static = static_library('econf',
-			libeconf_src,
-			include_directories : inc,
-			install : true)
-
 libeconf_dep = declare_dependency(
   link_with : lib,
   include_directories : inc,


### PR DESCRIPTION
The correct way to build a static library with meson is to use the `-Ddefault_library=both` or `-Ddefault_library=static` meson configure arguments.