### PR TITLE
cmake: Fix .pc file with absolute CMAKE_INSTALL_<dir>

### DIFF
--- a/cmake/libeconf.pc.in
+++ b/cmake/libeconf.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@PKG_CONFIG_LIBDIR@
+includedir=@PKG_CONFIG_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,6 +36,16 @@ set_target_properties(econf PROPERTIES
   LINK_FLAGS "-Wl,--no-undefined -Wl,--no-undefined-version -Wl,--version-script,\"${PROJECT_SOURCE_DIR}/lib/libeconf.map\""
 )
 
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(PKG_CONFIG_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
 # Install the library
 configure_file(${PROJECT_SOURCE_DIR}/cmake/libeconf.pc.in ${CMAKE_BINARY_DIR}/libeconf.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/libeconf.pc


### PR DESCRIPTION
Per <https://cmake.org/cmake/help/v4.1/module/GNUInstallDirs.html> `CMAKE_INSTALL_<dir>` variables can be absolute. In this case they should not be appended to the prefix in the generated `.pc` file.